### PR TITLE
edit links to colab and images, also edit lib versions

### DIFF
--- a/jupyter-notebooks/LatentConstraints.ipynb
+++ b/jupyter-notebooks/LatentConstraints.ipynb
@@ -122,9 +122,8 @@
         }
       },
       "source": [
-        "# This notebook requires DeepMind's sonnet library, which itself\n",
-        "# requires the nightly build of TensorFlow. The command below \n",
-        "# installs both.\n",
+        "# This notebook requires DeepMind's sonnet library 1.x, which itself\n",
+        "# requires TensorFlow 1.x. The command below installs both.\n",
         "!pip install -q -U \"dm-sonnet<2\" \"tensorflow<2\"\n",
         "\n",
         "import os\n",

--- a/jupyter-notebooks/LatentConstraints.ipynb
+++ b/jupyter-notebooks/LatentConstraints.ipynb
@@ -57,7 +57,7 @@
         }
       },
       "source": [
-        "A version of this notebook with accompanying cloud instance can be found at [https://colab.research.google.com/notebook#fileId=/v2/external/notebooks/latent_constraints/latentconstraints.ipynb](https://colab.research.google.com/notebook#fileId=/v2/external/notebooks/latent_constraints/latentconstraints.ipynb&scrollTo=oKI30KBUEN6l)\n",
+        "A version of this notebook with accompanying cloud instance can be found at [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/notebooks/latent_constraints/latentconstraints.ipynb)\n",
         "\n",
         "# Latent Constraints: Conditional Generation from Unconditional Generative Models\n",
         "### ___Jesse Engel, Matthew Hoffman, Adam Roberts___ [arXiv link](http://arxiv.org/abs/1711.05772)\n",
@@ -74,8 +74,8 @@
         "\n",
         "___\n",
         "\n",
-        "![](http://download.magenta.tensorflow.org/models/latent_constraints/ipynb_figs/diagram.png =400x400 \"Latent Space Diagram\")\n",
-        "![](http://download.magenta.tensorflow.org/models/latent_constraints/ipynb_figs/cgen.png =540x500 \"Conditional Generation with and without a distance penalty\")\n",
+        "<img src=\"http://download.magenta.tensorflow.org/models/latent_constraints/ipynb_figs/diagram.png\" alt=\"Latent Space Diagram\" height=400>\n",
+        "<img src=\"http://download.magenta.tensorflow.org/models/latent_constraints/ipynb_figs/cgen.png\" alt=\"Conditional Generation with and without a distance penalty\" wight=540 height=500>\n",
         "\n",
         "___\n",
         "\n",
@@ -125,7 +125,7 @@
         "# This notebook requires DeepMind's sonnet library, which itself\n",
         "# requires the nightly build of TensorFlow. The command below \n",
         "# installs both.\n",
-        "!pip install -q -U dm-sonnet tf-nightly\n",
+        "!pip install -q -U \"dm-sonnet<2\" \"tensorflow<2\"\n",
         "\n",
         "import os\n",
         "import PIL\n",


### PR DESCRIPTION
Hi!
Created colab-badge and fixed links to images.
When run notebook as it is, error in model classes appeared: `module 'sonnet' has no attribute 'AbstractModule'`
Found this [issue](https://github.com/deepmind/sonnet/issues/128#issuecomment-538731379)
Seems that there were library conflict and that notebook was mad with both sonnet version under 2 and tensorflow below 2.